### PR TITLE
release 1.2.1

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -56,3 +56,4 @@ codecov.yml
 .travis.yml
 .eslintrc.yaml
 .eslintrc.json
+test

--- a/Changes.md
+++ b/Changes.md
@@ -9,6 +9,14 @@
 ### [1.1.0] - 2022-09-14
 
 - Do not insert banner in text attachments, #3
+
+
+### [1.0.1] - 2024-04-03
+
+- dep(libqp): bump 1.1 -> 2.1
+- dep(libmime): bump 5.1 -> 5.3.4
+- dep(mocha & eslint): remove from devDeps (install as needed with npx)
+- add ./test to .npmignore
 - chore(climate): configure code climate
 
 
@@ -19,5 +27,6 @@
 
 
 [1.0.0]: https://github.com/haraka/email-message/releases/tag/1.0.0
+[1.0.1]: https://github.com/haraka/email-message/releases/tag/1.0.1
 [1.1.0]: https://github.com/haraka/email-message/releases/tag/1.1.0
 [1.2.0]: https://github.com/haraka/email-message/releases/tag/1.2.0

--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,14 @@
 
 ### Unreleased
 
+### [1.2.1] - 2024-04-03
+
+- dep(libqp): bump 1.1 -> 2.1
+- dep(libmime): bump 5.1 -> 5.3.4
+- dep(mocha & eslint): remove from devDeps (install as needed with npx)
+- add ./test to .npmignore
+
+
 ### [1.2.0] - 2022-11-29
 
 - dep(libqp): update from 1.1 -> 2.0.1
@@ -9,14 +17,6 @@
 ### [1.1.0] - 2022-09-14
 
 - Do not insert banner in text attachments, #3
-
-
-### [1.0.1] - 2024-04-03
-
-- dep(libqp): bump 1.1 -> 2.1
-- dep(libmime): bump 5.1 -> 5.3.4
-- dep(mocha & eslint): remove from devDeps (install as needed with npx)
-- add ./test to .npmignore
 - chore(climate): configure code climate
 
 
@@ -27,6 +27,5 @@
 
 
 [1.0.0]: https://github.com/haraka/email-message/releases/tag/1.0.0
-[1.0.1]: https://github.com/haraka/email-message/releases/tag/1.0.1
 [1.1.0]: https://github.com/haraka/email-message/releases/tag/1.1.0
 [1.2.0]: https://github.com/haraka/email-message/releases/tag/1.2.0

--- a/Changes.md
+++ b/Changes.md
@@ -3,8 +3,9 @@
 
 ### [1.2.1] - 2024-04-03
 
-- dep(libqp): bump 1.1 -> 2.1
-- dep(libmime): bump 5.1 -> 5.3.4
+- dep(libqp): bump to 2.1.0
+- dep(libmime): bump to 5.3.4
+- dep(haraka-message-stream): bump to 1.2.1
 - dep(mocha & eslint): remove from devDeps (install as needed with npx)
 - add ./test to .npmignore
 

--- a/package.json
+++ b/package.json
@@ -4,10 +4,10 @@
   "description": "Haraka email message",
   "main": "index.js",
   "scripts": {
-    "lint": "npx eslint *.js test",
-    "lintfix": "npx eslint --fix *.js test",
+    "lint": "npx eslint@^8 *.js test",
+    "lintfix": "npx eslint@^8 --fix *.js test",
     "versions": "npx dependency-version-checker check",
-    "test": "npx mocha"
+    "test": "npx mocha@^10"
   },
   "repository": {
     "type": "git",
@@ -24,15 +24,13 @@
   },
   "homepage": "https://github.com/haraka/email-message#readme",
   "devDependencies": {
-    "eslint": ">=8",
-    "eslint-plugin-haraka": "*",
-    "mocha": ">=9.0.0"
+    "eslint-plugin-haraka": "^1.0.15"
   },
   "dependencies": {
     "haraka-config": "^1.1.0",
-    "haraka-message-stream": "^1.2.0",
+    "haraka-message-stream": "^1.2.1",
     "iconv": "^3.0.1",
-    "libmime": "^5.1.0",
-    "libqp": "^2.0.1"
+    "libmime": "^5.3.4",
+    "libqp": "^2.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "haraka-email-message",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Haraka email message",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
- dep(libqp): bump to 2.1.0
- dep(libmime): bump to 5.3.4
- dep(haraka-message-stream): bump to 1.2.1
- dep(mocha & eslint): remove from devDeps (install as needed with npx)
- add ./test to .npmignore
