### PR TITLE
allow attachment filenames containing semicolons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Unreleased
 
+### [1.2.4] - 2024-09-27
+- allow attachment filenames containing semicolons https://github.com/haraka/email-message/issues/12
+
 ### [1.2.3] - 2024-04-24
 
 - style(es6): replace forEach with for...of

--- a/index.js
+++ b/index.js
@@ -438,17 +438,20 @@ class Body extends events.EventEmitter {
     }
     this.ct = ct;
 
+    const buildRegex = (key) => new RegExp(`${key}\\s*=\\s*"([^"]+)"|${key}\\s*=\\s*"?([^";]+)"?`, 'i');
+    const matchKey = (test, key) => test.match(buildRegex(key))?.filter(item => item);
+
     let match;
     if (/^(?:text|message)\//i.test(ct) && !/^attachment/i.test(cd)) {
       this.state = 'body';
     } else if (/^multipart\//i.test(ct)) {
-      match = ct.match(/boundary\s*=\s*"?([^";]+)"?/i);
+      match = matchKey(ct, 'boundary');
       this.boundary = match ? match[1] : '';
       this.state = 'multipart_preamble';
     } else {
-      match = cd.match(/name\s*=\s*"?([^";]+)"?/i);
+      match = matchKey(cd, 'name');
       if (!match) {
-        match = ct.match(/name\s*=\s*"?([^";]+)"?/i);
+        match = matchKey(ct, 'name');
       }
       const filename = match ? match[1] : '';
       this.attachment_stream = exports.createAttachmentStream(this.header);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "haraka-email-message",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "Haraka email message",
   "main": "index.js",
   "files": [

--- a/test/body.js
+++ b/test/body.js
@@ -406,4 +406,68 @@ describe('body', function () {
       done();
     });
   });
+
+  describe('attachments', function () {
+    describe('content-type-name', function () {
+      it('with-quotes', function (done) {
+        const body = new Body();
+        body.on('attachment_start', (ct, filename) => {
+          assert.equal(filename, 'aaaa.zip');
+          done();
+        });
+        body.header.parse([
+          'Content-Type: application/zip; name="aaaa.zip"'
+        ]);
+        body.parse_start('');
+      });
+
+      it('without-quotes', function (done) {
+        const body = new Body();
+        body.on('attachment_start', (ct, filename) => {
+          assert.equal(filename, 'aaaa.zip');
+          done();
+        });
+        body.header.parse([
+          'Content-Type: application/zip; name=aaaa.zip'
+        ]);
+        body.parse_start('');
+      });
+
+      it('with-quotes-and-semicolons', function (done) {
+        const body = new Body();
+        body.on('attachment_start', (ct, filename) => {
+          assert.equal(filename, 'aaaa; bbb; cccc.zip');
+          done();
+        });
+        body.header.parse([
+          'Content-Type: application/zip; name="aaaa; bbb; cccc.zip"'
+        ]);
+        body.parse_start('');
+      });
+
+      it('with-one-quote-left', function (done) {
+        const body = new Body();
+        body.on('attachment_start', (ct, filename) => {
+          assert.equal(filename, 'aaaa');
+          done();
+        });
+        body.header.parse([
+          'Content-Type: application/zip; name="aaaa; bbb; cccc.zip'
+        ]);
+        body.parse_start('');
+      });
+
+      it('with-one-quote-right', function (done) {
+        const body = new Body();
+        body.on('attachment_start', (ct, filename) => {
+          assert.equal(filename, 'aaaa');
+          done();
+        });
+        body.header.parse([
+          'Content-Type: application/zip; name=aaaa; bbb; cccc.zip"'
+        ]);
+        body.parse_start('');
+      });
+    });
+  });
 });


### PR DESCRIPTION
Allow attachment filenames containing semicolons.

Fixes #12

Changes proposed in this pull request:

- Change Content-Type parsing regex from `name\s*=\s*"?([^";]+)"?` to `name\s*=\s*"([^"]+)"|name\s*=\s*"?([^";]+)"?`.
- Define the regex once instead of 3 times.

The new regex presents a new matching possibility on the left: selecting all non quote characters between two quotes (including semicolons).

The right possibility is the original one that excludes semicolons. We keep the optional quotes in the right one to still handle malformatted cases with only 1 double quote.

More elegant approaches are possible, but these are often less readable, to me at least. For instance:

`name\s*=\s*"?(?:(?=([^"]+)")|([^";]+)"?)`.

Checklist:

- [ ] docs updated
- [x] tests updated
- [x] Changes.md updated
